### PR TITLE
Add test for single occurance

### DIFF
--- a/06-arrays/tests.js
+++ b/06-arrays/tests.js
@@ -49,6 +49,7 @@ describe("#containsAnyTwice", function () {
         expect(containsAnyTwice([1, 2], ["hello", 1, "world", 1])).toBe(true);
         expect(containsAnyTwice([], ["always", "will", "return", "false"])).toBe(false);
         expect(containsAnyTwice(["hello", "world"], ["hello", "hello", "world", "world"])).toBe(true);
+        expect(containsAnyTwice(["hello"], ['hello', 'world', 'world'])).toBe(false);
     });
 
     it ("should throw an error if either of the arguments are not arrays", function () {


### PR DESCRIPTION
The tests as written do not cover the scenario where the code under test returns true if the value appears one or more times (rather than two or more times.)  Adds a new test where the first array contains one value that appears only once in the second array, that is expected to be false.
